### PR TITLE
Drop dependency on OpenJDK 8

### DIFF
--- a/mbi/core/src/org/fedoraproject/mbi/tool/compiler/CompilerTool.java
+++ b/mbi/core/src/org/fedoraproject/mbi/tool/compiler/CompilerTool.java
@@ -116,22 +116,8 @@ public class CompilerTool
         List<String> options = new ArrayList<>();
         options.add( "-d" );
         options.add( getClassesDir().toString() );
-        if ( release == 11 )
-        {
-            options.add( "-source" );
-            options.add( "11" );
-            options.add( "-target" );
-            options.add( "11" );
-        }
-        else
-        {
-            options.add( "-source" );
-            options.add( "1.8" );
-            options.add( "-target" );
-            options.add( "1.8" );
-            options.add( "-bootclasspath" );
-            options.add( "/usr/lib/jvm/java-1.8.0-openjdk/jre/lib/rt.jar:/usr/lib/jvm/java-1.8.0-openjdk/jre/lib/jce.jar" );
-        }
+        options.add( "--release" );
+        options.add( release + "" );
         options.add( "-cp" );
         options.add( getClassPath().stream().map( Path::toString ).collect( Collectors.joining( ":" ) ) );
         StringWriter compilerOutput = new StringWriter();

--- a/mbi/core/src/org/fedoraproject/mbi/tool/compiler/EclipseProjectGenerator.java
+++ b/mbi/core/src/org/fedoraproject/mbi/tool/compiler/EclipseProjectGenerator.java
@@ -81,8 +81,7 @@ class EclipseProjectGenerator
         }
         String vm = release == 11 ? "11" : "1.8";
         eclipseClasspath.append( "<classpathentry kind=\"con\""
-            + " path=\"org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-"
-            + vm + "\"/>\n" );
+            + " path=\"org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11\"/>\n" );
         eclipseClasspath.append( "<classpathentry kind=\"output\" path=\"bin\"/>\n" );
         try ( BufferedWriter bw = Files.newBufferedWriter( outputDir.resolve( ".classpath" ) ) )
         {
@@ -99,6 +98,8 @@ class EclipseProjectGenerator
             bw.write( "eclipse.preferences.version=1\n" );
             bw.write( "org.eclipse.jdt.core.compiler.compliance=" + vm + "\n" );
             bw.write( "org.eclipse.jdt.core.compiler.source=" + vm + "\n" );
+            bw.write( "org.eclipse.jdt.core.compiler.codegen.targetPlatform=" + vm + "\n" );
+            bw.write( "org.eclipse.jdt.core.compiler.release=enabled\n" );
             bw.write( "org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning\n" );
         }
     }

--- a/patches/guava/0001-Fix-compilation-error-with-ECJ.patch
+++ b/patches/guava/0001-Fix-compilation-error-with-ECJ.patch
@@ -1,7 +1,7 @@
-From a70f7badf763bbfa7cb07313fc8fd88c30154ad3 Mon Sep 17 00:00:00 2001
+From 66741fbe9b3d6fbd5ed1550ff240d2b1da11b739 Mon Sep 17 00:00:00 2001
 From: Mikolaj Izdebski <mizdebsk@redhat.com>
 Date: Mon, 6 Jul 2020 15:00:26 +0200
-Subject: [PATCH] Fix compilation error with ECJ
+Subject: [PATCH 1/2] Fix compilation error with ECJ
 
 ---
  .../com/google/common/collect/ImmutableClassToInstanceMap.java  | 2 +-

--- a/patches/guava/0002-Remove-use-of-sun.misc.Unsafe.patch
+++ b/patches/guava/0002-Remove-use-of-sun.misc.Unsafe.patch
@@ -1,0 +1,471 @@
+From c1c8c38af32487e06cbc94262234bd9fec19d001 Mon Sep 17 00:00:00 2001
+From: Mikolaj Izdebski <mizdebsk@redhat.com>
+Date: Mon, 30 Nov 2020 12:16:22 +0100
+Subject: [PATCH 2/2] Remove use of sun.misc.Unsafe
+
+---
+ .../com/google/common/cache/LongAddables.java |  11 +-
+ .../common/hash/LittleEndianByteArray.java    | 109 +--------------
+ .../com/google/common/hash/LongAddables.java  |  11 +-
+ .../common/primitives/UnsignedBytes.java      | 128 +-----------------
+ .../util/concurrent/AbstractFuture.java       |  90 +-----------
+ 5 files changed, 5 insertions(+), 344 deletions(-)
+
+diff --git a/guava/src/com/google/common/cache/LongAddables.java b/guava/src/com/google/common/cache/LongAddables.java
+index 203d2ef731..cbca0cd1d3 100644
+--- a/guava/src/com/google/common/cache/LongAddables.java
++++ b/guava/src/com/google/common/cache/LongAddables.java
+@@ -29,16 +29,7 @@ final class LongAddables {
+ 
+   static {
+     Supplier<LongAddable> supplier;
+-    try {
+-      new LongAdder(); // trigger static initialization of the LongAdder class, which may fail
+-      supplier =
+-          new Supplier<LongAddable>() {
+-            @Override
+-            public LongAddable get() {
+-              return new LongAdder();
+-            }
+-          };
+-    } catch (Throwable t) { // we really want to catch *everything*
++    {
+       supplier =
+           new Supplier<LongAddable>() {
+             @Override
+diff --git a/guava/src/com/google/common/hash/LittleEndianByteArray.java b/guava/src/com/google/common/hash/LittleEndianByteArray.java
+index 91f57371d9..56369b7e0b 100644
+--- a/guava/src/com/google/common/hash/LittleEndianByteArray.java
++++ b/guava/src/com/google/common/hash/LittleEndianByteArray.java
+@@ -16,7 +16,6 @@ package com.google.common.hash;
+ 
+ import com.google.common.primitives.Longs;
+ import java.nio.ByteOrder;
+-import sun.misc.Unsafe;
+ 
+ /**
+  * Utility functions for loading and storing values from a byte array.
+@@ -103,7 +102,7 @@ final class LittleEndianByteArray {
+    * that is slower than Unsafe.get/store but faster than the pure-Java mask-and-shift.
+    */
+   static boolean usingUnsafe() {
+-    return (byteArray instanceof UnsafeByteArray);
++    return false;
+   }
+ 
+   /**
+@@ -118,90 +117,6 @@ final class LittleEndianByteArray {
+     void putLongLittleEndian(byte[] array, int offset, long value);
+   }
+ 
+-  /**
+-   * The only reference to Unsafe is in this nested class. We set things up so that if
+-   * Unsafe.theUnsafe is inaccessible, the attempt to load the nested class fails, and the outer
+-   * class's static initializer can fall back on a non-Unsafe version.
+-   */
+-  private enum UnsafeByteArray implements LittleEndianBytes {
+-    // Do *not* change the order of these constants!
+-    UNSAFE_LITTLE_ENDIAN {
+-      @Override
+-      public long getLongLittleEndian(byte[] array, int offset) {
+-        return theUnsafe.getLong(array, (long) offset + BYTE_ARRAY_BASE_OFFSET);
+-      }
+-
+-      @Override
+-      public void putLongLittleEndian(byte[] array, int offset, long value) {
+-        theUnsafe.putLong(array, (long) offset + BYTE_ARRAY_BASE_OFFSET, value);
+-      }
+-    },
+-    UNSAFE_BIG_ENDIAN {
+-      @Override
+-      public long getLongLittleEndian(byte[] array, int offset) {
+-        long bigEndian = theUnsafe.getLong(array, (long) offset + BYTE_ARRAY_BASE_OFFSET);
+-        // The hardware is big-endian, so we need to reverse the order of the bytes.
+-        return Long.reverseBytes(bigEndian);
+-      }
+-
+-      @Override
+-      public void putLongLittleEndian(byte[] array, int offset, long value) {
+-        // Reverse the order of the bytes before storing, since we're on big-endian hardware.
+-        long littleEndianValue = Long.reverseBytes(value);
+-        theUnsafe.putLong(array, (long) offset + BYTE_ARRAY_BASE_OFFSET, littleEndianValue);
+-      }
+-    };
+-
+-    // Provides load and store operations that use native instructions to get better performance.
+-    private static final Unsafe theUnsafe;
+-
+-    // The offset to the first element in a byte array.
+-    private static final int BYTE_ARRAY_BASE_OFFSET;
+-
+-    /**
+-     * Returns a sun.misc.Unsafe. Suitable for use in a 3rd party package. Replace with a simple
+-     * call to Unsafe.getUnsafe when integrating into a jdk.
+-     *
+-     * @return a sun.misc.Unsafe instance if successful
+-     */
+-    private static sun.misc.Unsafe getUnsafe() {
+-      try {
+-        return sun.misc.Unsafe.getUnsafe();
+-      } catch (SecurityException tryReflectionInstead) {
+-        // We'll try reflection instead.
+-      }
+-      try {
+-        return java.security.AccessController.doPrivileged(
+-            new java.security.PrivilegedExceptionAction<sun.misc.Unsafe>() {
+-              @Override
+-              public sun.misc.Unsafe run() throws Exception {
+-                Class<sun.misc.Unsafe> k = sun.misc.Unsafe.class;
+-                for (java.lang.reflect.Field f : k.getDeclaredFields()) {
+-                  f.setAccessible(true);
+-                  Object x = f.get(null);
+-                  if (k.isInstance(x)) {
+-                    return k.cast(x);
+-                  }
+-                }
+-                throw new NoSuchFieldError("the Unsafe");
+-              }
+-            });
+-      } catch (java.security.PrivilegedActionException e) {
+-        throw new RuntimeException("Could not initialize intrinsics", e.getCause());
+-      }
+-    }
+-
+-    static {
+-      theUnsafe = getUnsafe();
+-      BYTE_ARRAY_BASE_OFFSET = theUnsafe.arrayBaseOffset(byte[].class);
+-
+-      // sanity check - this should never fail
+-      if (theUnsafe.arrayIndexScale(byte[].class) != 1) {
+-        throw new AssertionError();
+-      }
+-    }
+-  }
+-
+   /** Fallback implementation for when Unsafe is not available in our current environment. */
+   private enum JavaLittleEndianBytes implements LittleEndianBytes {
+     INSTANCE {
+@@ -230,28 +145,6 @@ final class LittleEndianByteArray {
+ 
+   static {
+     LittleEndianBytes theGetter = JavaLittleEndianBytes.INSTANCE;
+-    try {
+-      /*
+-        UnsafeByteArray uses Unsafe.getLong() in an unsupported way, which is known to cause crashes
+-        on Android when running in 32-bit mode. For maximum safety, we shouldn't use
+-        Unsafe.getLong() at all, but the performance benefit on x86_64 is too great to ignore, so as
+-        a compromise, we enable the optimization only on platforms that we specifically know to
+-        work.
+-
+-        In the future, the use of Unsafe.getLong() should be replaced by ByteBuffer.getLong(), which
+-        will have an efficient native implementation in JDK 9.
+-
+-      */
+-      final String arch = System.getProperty("os.arch");
+-      if ("amd64".equals(arch)) {
+-        theGetter =
+-            ByteOrder.nativeOrder().equals(ByteOrder.LITTLE_ENDIAN)
+-                ? UnsafeByteArray.UNSAFE_LITTLE_ENDIAN
+-                : UnsafeByteArray.UNSAFE_BIG_ENDIAN;
+-      }
+-    } catch (Throwable t) {
+-      // ensure we really catch *everything*
+-    }
+     byteArray = theGetter;
+   }
+ 
+diff --git a/guava/src/com/google/common/hash/LongAddables.java b/guava/src/com/google/common/hash/LongAddables.java
+index d2768bcf5c..6c889a197a 100644
+--- a/guava/src/com/google/common/hash/LongAddables.java
++++ b/guava/src/com/google/common/hash/LongAddables.java
+@@ -27,16 +27,7 @@ final class LongAddables {
+ 
+   static {
+     Supplier<LongAddable> supplier;
+-    try {
+-      new LongAdder(); // trigger static initialization of the LongAdder class, which may fail
+-      supplier =
+-          new Supplier<LongAddable>() {
+-            @Override
+-            public LongAddable get() {
+-              return new LongAdder();
+-            }
+-          };
+-    } catch (Throwable t) { // we really want to catch *everything*
++    {
+       supplier =
+           new Supplier<LongAddable>() {
+             @Override
+diff --git a/guava/src/com/google/common/primitives/UnsignedBytes.java b/guava/src/com/google/common/primitives/UnsignedBytes.java
+index 4275f8a6ec..da6013abd0 100644
+--- a/guava/src/com/google/common/primitives/UnsignedBytes.java
++++ b/guava/src/com/google/common/primitives/UnsignedBytes.java
+@@ -25,7 +25,6 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
+ import java.nio.ByteOrder;
+ import java.util.Arrays;
+ import java.util.Comparator;
+-import sun.misc.Unsafe;
+ 
+ /**
+  * Static utility methods pertaining to {@code byte} primitives that interpret values as
+@@ -290,124 +289,6 @@ public final class UnsignedBytes {
+ 
+     static final Comparator<byte[]> BEST_COMPARATOR = getBestComparator();
+ 
+-    @VisibleForTesting
+-    enum UnsafeComparator implements Comparator<byte[]> {
+-      INSTANCE;
+-
+-      static final boolean BIG_ENDIAN = ByteOrder.nativeOrder().equals(ByteOrder.BIG_ENDIAN);
+-
+-      /*
+-       * The following static final fields exist for performance reasons.
+-       *
+-       * In UnsignedBytesBenchmark, accessing the following objects via static final fields is the
+-       * fastest (more than twice as fast as the Java implementation, vs ~1.5x with non-final static
+-       * fields, on x86_32) under the Hotspot server compiler. The reason is obviously that the
+-       * non-final fields need to be reloaded inside the loop.
+-       *
+-       * And, no, defining (final or not) local variables out of the loop still isn't as good
+-       * because the null check on the theUnsafe object remains inside the loop and
+-       * BYTE_ARRAY_BASE_OFFSET doesn't get constant-folded.
+-       *
+-       * The compiler can treat static final fields as compile-time constants and can constant-fold
+-       * them while (final or not) local variables are run time values.
+-       */
+-
+-      static final Unsafe theUnsafe = getUnsafe();
+-
+-      /** The offset to the first element in a byte array. */
+-      static final int BYTE_ARRAY_BASE_OFFSET = theUnsafe.arrayBaseOffset(byte[].class);
+-
+-      static {
+-        // fall back to the safer pure java implementation unless we're in
+-        // a 64-bit JVM with an 8-byte aligned field offset.
+-        if (!("64".equals(System.getProperty("sun.arch.data.model"))
+-            && (BYTE_ARRAY_BASE_OFFSET % 8) == 0
+-            // sanity check - this should never fail
+-            && theUnsafe.arrayIndexScale(byte[].class) == 1)) {
+-          throw new Error(); // force fallback to PureJavaComparator
+-        }
+-      }
+-
+-      /**
+-       * Returns a sun.misc.Unsafe. Suitable for use in a 3rd party package. Replace with a simple
+-       * call to Unsafe.getUnsafe when integrating into a jdk.
+-       *
+-       * @return a sun.misc.Unsafe
+-       */
+-      private static sun.misc.Unsafe getUnsafe() {
+-        try {
+-          return sun.misc.Unsafe.getUnsafe();
+-        } catch (SecurityException e) {
+-          // that's okay; try reflection instead
+-        }
+-        try {
+-          return java.security.AccessController.doPrivileged(
+-              new java.security.PrivilegedExceptionAction<sun.misc.Unsafe>() {
+-                @Override
+-                public sun.misc.Unsafe run() throws Exception {
+-                  Class<sun.misc.Unsafe> k = sun.misc.Unsafe.class;
+-                  for (java.lang.reflect.Field f : k.getDeclaredFields()) {
+-                    f.setAccessible(true);
+-                    Object x = f.get(null);
+-                    if (k.isInstance(x)) {
+-                      return k.cast(x);
+-                    }
+-                  }
+-                  throw new NoSuchFieldError("the Unsafe");
+-                }
+-              });
+-        } catch (java.security.PrivilegedActionException e) {
+-          throw new RuntimeException("Could not initialize intrinsics", e.getCause());
+-        }
+-      }
+-
+-      @Override
+-      public int compare(byte[] left, byte[] right) {
+-        final int stride = 8;
+-        int minLength = Math.min(left.length, right.length);
+-        int strideLimit = minLength & ~(stride - 1);
+-        int i;
+-
+-        /*
+-         * Compare 8 bytes at a time. Benchmarking on x86 shows a stride of 8 bytes is no slower
+-         * than 4 bytes even on 32-bit. On the other hand, it is substantially faster on 64-bit.
+-         */
+-        for (i = 0; i < strideLimit; i += stride) {
+-          long lw = theUnsafe.getLong(left, BYTE_ARRAY_BASE_OFFSET + (long) i);
+-          long rw = theUnsafe.getLong(right, BYTE_ARRAY_BASE_OFFSET + (long) i);
+-          if (lw != rw) {
+-            if (BIG_ENDIAN) {
+-              return UnsignedLongs.compare(lw, rw);
+-            }
+-
+-            /*
+-             * We want to compare only the first index where left[index] != right[index]. This
+-             * corresponds to the least significant nonzero byte in lw ^ rw, since lw and rw are
+-             * little-endian. Long.numberOfTrailingZeros(diff) tells us the least significant
+-             * nonzero bit, and zeroing out the first three bits of L.nTZ gives us the shift to get
+-             * that least significant nonzero byte.
+-             */
+-            int n = Long.numberOfTrailingZeros(lw ^ rw) & ~0x7;
+-            return ((int) ((lw >>> n) & UNSIGNED_MASK)) - ((int) ((rw >>> n) & UNSIGNED_MASK));
+-          }
+-        }
+-
+-        // The epilogue to cover the last (minLength % stride) elements.
+-        for (; i < minLength; i++) {
+-          int result = UnsignedBytes.compare(left[i], right[i]);
+-          if (result != 0) {
+-            return result;
+-          }
+-        }
+-        return left.length - right.length;
+-      }
+-
+-      @Override
+-      public String toString() {
+-        return "UnsignedBytes.lexicographicalComparator() (sun.misc.Unsafe version)";
+-      }
+-    }
+-
+     enum PureJavaComparator implements Comparator<byte[]> {
+       INSTANCE;
+ 
+@@ -434,14 +315,7 @@ public final class UnsignedBytes {
+      * to do so.
+      */
+     static Comparator<byte[]> getBestComparator() {
+-      try {
+-        Class<?> theClass = Class.forName(UNSAFE_COMPARATOR_NAME);
+-
+-        // yes, UnsafeComparator does implement Comparator<byte[]>
+-        @SuppressWarnings("unchecked")
+-        Comparator<byte[]> comparator = (Comparator<byte[]>) theClass.getEnumConstants()[0];
+-        return comparator;
+-      } catch (Throwable t) { // ensure we really catch *everything*
++      {
+         return lexicographicalComparatorJavaImpl();
+       }
+     }
+diff --git a/guava/src/com/google/common/util/concurrent/AbstractFuture.java b/guava/src/com/google/common/util/concurrent/AbstractFuture.java
+index 9cace28eac..992d7580fa 100644
+--- a/guava/src/com/google/common/util/concurrent/AbstractFuture.java
++++ b/guava/src/com/google/common/util/concurrent/AbstractFuture.java
+@@ -142,13 +142,9 @@ public abstract class AbstractFuture<V> extends InternalFutureFailureAccess
+ 
+   static {
+     AtomicHelper helper;
+-    Throwable thrownUnsafeFailure = null;
+     Throwable thrownAtomicReferenceFieldUpdaterFailure = null;
+ 
+-    try {
+-      helper = new UnsafeAtomicHelper();
+-    } catch (Throwable unsafeFailure) {
+-      thrownUnsafeFailure = unsafeFailure;
++    {
+       // catch absolutely everything and fall through to our 'SafeAtomicHelper'
+       // The access control checks that ARFU does means the caller class has to be AbstractFuture
+       // instead of SafeAtomicHelper, so we annoyingly define these here
+@@ -179,7 +175,6 @@ public abstract class AbstractFuture<V> extends InternalFutureFailureAccess
+     // Log after all static init is finished; if an installed logger uses any Futures methods, it
+     // shouldn't break in cases where reflection is missing/broken.
+     if (thrownAtomicReferenceFieldUpdaterFailure != null) {
+-      log.log(Level.SEVERE, "UnsafeAtomicHelper is broken!", thrownUnsafeFailure);
+       log.log(
+           Level.SEVERE, "SafeAtomicHelper is broken!", thrownAtomicReferenceFieldUpdaterFailure);
+     }
+@@ -1200,89 +1195,6 @@ public abstract class AbstractFuture<V> extends InternalFutureFailureAccess
+     abstract boolean casValue(AbstractFuture<?> future, Object expect, Object update);
+   }
+ 
+-  /**
+-   * {@link AtomicHelper} based on {@link sun.misc.Unsafe}.
+-   *
+-   * <p>Static initialization of this class will fail if the {@link sun.misc.Unsafe} object cannot
+-   * be accessed.
+-   */
+-  private static final class UnsafeAtomicHelper extends AtomicHelper {
+-    static final sun.misc.Unsafe UNSAFE;
+-    static final long LISTENERS_OFFSET;
+-    static final long WAITERS_OFFSET;
+-    static final long VALUE_OFFSET;
+-    static final long WAITER_THREAD_OFFSET;
+-    static final long WAITER_NEXT_OFFSET;
+-
+-    static {
+-      sun.misc.Unsafe unsafe = null;
+-      try {
+-        unsafe = sun.misc.Unsafe.getUnsafe();
+-      } catch (SecurityException tryReflectionInstead) {
+-        try {
+-          unsafe =
+-              AccessController.doPrivileged(
+-                  new PrivilegedExceptionAction<sun.misc.Unsafe>() {
+-                    @Override
+-                    public sun.misc.Unsafe run() throws Exception {
+-                      Class<sun.misc.Unsafe> k = sun.misc.Unsafe.class;
+-                      for (java.lang.reflect.Field f : k.getDeclaredFields()) {
+-                        f.setAccessible(true);
+-                        Object x = f.get(null);
+-                        if (k.isInstance(x)) {
+-                          return k.cast(x);
+-                        }
+-                      }
+-                      throw new NoSuchFieldError("the Unsafe");
+-                    }
+-                  });
+-        } catch (PrivilegedActionException e) {
+-          throw new RuntimeException("Could not initialize intrinsics", e.getCause());
+-        }
+-      }
+-      try {
+-        Class<?> abstractFuture = AbstractFuture.class;
+-        WAITERS_OFFSET = unsafe.objectFieldOffset(abstractFuture.getDeclaredField("waiters"));
+-        LISTENERS_OFFSET = unsafe.objectFieldOffset(abstractFuture.getDeclaredField("listeners"));
+-        VALUE_OFFSET = unsafe.objectFieldOffset(abstractFuture.getDeclaredField("value"));
+-        WAITER_THREAD_OFFSET = unsafe.objectFieldOffset(Waiter.class.getDeclaredField("thread"));
+-        WAITER_NEXT_OFFSET = unsafe.objectFieldOffset(Waiter.class.getDeclaredField("next"));
+-        UNSAFE = unsafe;
+-      } catch (Exception e) {
+-        throwIfUnchecked(e);
+-        throw new RuntimeException(e);
+-      }
+-    }
+-
+-    @Override
+-    void putThread(Waiter waiter, Thread newValue) {
+-      UNSAFE.putObject(waiter, WAITER_THREAD_OFFSET, newValue);
+-    }
+-
+-    @Override
+-    void putNext(Waiter waiter, Waiter newValue) {
+-      UNSAFE.putObject(waiter, WAITER_NEXT_OFFSET, newValue);
+-    }
+-
+-    /** Performs a CAS operation on the {@link #waiters} field. */
+-    @Override
+-    boolean casWaiters(AbstractFuture<?> future, Waiter expect, Waiter update) {
+-      return UNSAFE.compareAndSwapObject(future, WAITERS_OFFSET, expect, update);
+-    }
+-
+-    /** Performs a CAS operation on the {@link #listeners} field. */
+-    @Override
+-    boolean casListeners(AbstractFuture<?> future, Listener expect, Listener update) {
+-      return UNSAFE.compareAndSwapObject(future, LISTENERS_OFFSET, expect, update);
+-    }
+-
+-    /** Performs a CAS operation on the {@link #value} field. */
+-    @Override
+-    boolean casValue(AbstractFuture<?> future, Object expect, Object update) {
+-      return UNSAFE.compareAndSwapObject(future, VALUE_OFFSET, expect, update);
+-    }
+-  }
+-
+   /** {@link AtomicHelper} based on {@link AtomicReferenceFieldUpdater}. */
+   private static final class SafeAtomicHelper extends AtomicHelper {
+     final AtomicReferenceFieldUpdater<Waiter, Thread> waiterThreadUpdater;
+-- 
+2.26.2
+

--- a/patches/objenesis/0001-Remove-use-of-sun.misc.Unsafe.patch
+++ b/patches/objenesis/0001-Remove-use-of-sun.misc.Unsafe.patch
@@ -1,0 +1,104 @@
+From 65693a82d4e2cfe688a62b055d5575e36f54d9ff Mon Sep 17 00:00:00 2001
+From: Mikolaj Izdebski <mizdebsk@redhat.com>
+Date: Mon, 30 Nov 2020 11:32:51 +0100
+Subject: [PATCH] Remove use of sun.misc.Unsafe
+
+---
+ .../instantiator/util/DefineClassHelper.java  | 36 +------------------
+ .../strategy/StdInstantiatorStrategy.java     |  5 ++-
+ 2 files changed, 3 insertions(+), 38 deletions(-)
+
+diff --git a/main/src/main/java/org/objenesis/instantiator/util/DefineClassHelper.java b/main/src/main/java/org/objenesis/instantiator/util/DefineClassHelper.java
+index 72ebd06..758d25b 100644
+--- a/main/src/main/java/org/objenesis/instantiator/util/DefineClassHelper.java
++++ b/main/src/main/java/org/objenesis/instantiator/util/DefineClassHelper.java
+@@ -15,7 +15,6 @@
+  */
+ package org.objenesis.instantiator.util;
+ 
+-import sun.misc.Unsafe;
+ import org.objenesis.ObjenesisException;
+ import org.objenesis.strategy.PlatformDescription;
+ 
+@@ -38,38 +37,6 @@ public final class DefineClassHelper {
+                                     ClassLoader loader, ProtectionDomain protectionDomain);
+    }
+ 
+-   private static class Java8 extends Helper {
+-
+-      private final MethodHandle defineClass = defineClass();
+-
+-      private MethodHandle defineClass() {
+-         MethodType mt = MethodType.methodType(Class.class, String.class, byte[].class, int.class, int.class, ClassLoader.class, ProtectionDomain.class);
+-         MethodHandle m;
+-         try {
+-            m = MethodHandles.publicLookup().findVirtual(Unsafe.class, "defineClass", mt);
+-         } catch(NoSuchMethodException | IllegalAccessException e) {
+-            throw new ObjenesisException(e);
+-         }
+-         Unsafe unsafe = UnsafeUtils.getUnsafe();
+-         return m.bindTo(unsafe);
+-      }
+-
+-      @Override
+-      Class<?> defineClass(String className, byte[] b, int off, int len, Class<?> neighbor, ClassLoader loader, ProtectionDomain protectionDomain) {
+-         try {
+-            return (Class<?>) defineClass.invokeExact(className, b, off, len, loader, protectionDomain);
+-         } catch (Throwable e) {
+-            if(e instanceof Error) {
+-               throw (Error) e;
+-            }
+-            if(e instanceof RuntimeException) {
+-               throw (RuntimeException) e;
+-            }
+-            throw new ObjenesisException(e);
+-         }
+-      }
+-   }
+-
+    private static class Java11 extends Helper {
+ 
+       private final Class<?> module = module();
+@@ -135,8 +102,7 @@ public final class DefineClassHelper {
+ 
+    // Java 11+ removed sun.misc.Unsafe.defineClass, so we fallback to invoking defineClass on
+    // ClassLoader until we have an implementation that uses MethodHandles.Lookup.defineClass
+-   private static final Helper privileged = PlatformDescription.isAfterJava11() ?
+-      new Java11() : new Java8();
++   private static final Helper privileged = new Java11();
+ 
+    public static Class<?> defineClass(String name, byte[] b, int off, int len, Class<?> neighbor,
+                                       ClassLoader loader, ProtectionDomain protectionDomain) {
+diff --git a/main/src/main/java/org/objenesis/strategy/StdInstantiatorStrategy.java b/main/src/main/java/org/objenesis/strategy/StdInstantiatorStrategy.java
+index 4ff00ff..4ed9729 100644
+--- a/main/src/main/java/org/objenesis/strategy/StdInstantiatorStrategy.java
++++ b/main/src/main/java/org/objenesis/strategy/StdInstantiatorStrategy.java
+@@ -24,7 +24,6 @@ import org.objenesis.instantiator.basic.ObjectInputStreamInstantiator;
+ import org.objenesis.instantiator.gcj.GCJInstantiator;
+ import org.objenesis.instantiator.perc.PercInstantiator;
+ import org.objenesis.instantiator.sun.SunReflectionFactoryInstantiator;
+-import org.objenesis.instantiator.sun.UnsafeFactoryInstantiator;
+ 
+ import java.io.Serializable;
+ 
+@@ -70,7 +69,7 @@ public class StdInstantiatorStrategy extends BaseInstantiatorStrategy {
+       else if(PlatformDescription.isThisJVM(DALVIK)) {
+          if(PlatformDescription.isAndroidOpenJDK()) {
+             // Starting at Android N which is based on OpenJDK
+-            return new UnsafeFactoryInstantiator<>(type);
++            return new ObjectInputStreamInstantiator<>(type);
+          }
+          if(ANDROID_VERSION <= 10) {
+             // Android 2.3 Gingerbread and lower
+@@ -91,7 +90,7 @@ public class StdInstantiatorStrategy extends BaseInstantiatorStrategy {
+       }
+ 
+       // Fallback instantiator, should work with most modern JVM
+-      return new UnsafeFactoryInstantiator<>(type);
++      return new ObjectInputStreamInstantiator<>(type);
+ 
+    }
+ }
+-- 
+2.26.2
+

--- a/patches/xmlunit/0004-Drop-support-for-JAXB.patch
+++ b/patches/xmlunit/0004-Drop-support-for-JAXB.patch
@@ -1,0 +1,60 @@
+From 9866f331db726db0ac6af64649c308b01b34ea56 Mon Sep 17 00:00:00 2001
+From: Mikolaj Izdebski <mizdebsk@redhat.com>
+Date: Tue, 5 Nov 2019 12:14:08 +0100
+Subject: [PATCH 4/4] Drop support for JAXB
+
+---
+ xmlunit-core/src/main/java/org/xmlunit/builder/Input.java  | 4 ++--
+ .../src/test/java/org/xmlunit/builder/InputTest.java       | 7 -------
+ 2 files changed, 2 insertions(+), 9 deletions(-)
+
+diff --git a/xmlunit-core/src/main/java/org/xmlunit/builder/Input.java b/xmlunit-core/src/main/java/org/xmlunit/builder/Input.java
+index 5321ff7..2b13cac 100644
+--- a/xmlunit-core/src/main/java/org/xmlunit/builder/Input.java
++++ b/xmlunit-core/src/main/java/org/xmlunit/builder/Input.java
+@@ -150,8 +150,8 @@ public class Input {
+     /**
+      * Build a Source from a Jaxb-Object.
+      */
+-    public static JaxbBuilder fromJaxb(Object jaxbObject) {
+-        return new JaxbBuilder(jaxbObject);
++    public static Builder fromJaxb(Object jaxbObject) {
++        throw new RuntimeException("This implementation has JAXB support removed");
+     }
+ 
+     /**
+diff --git a/xmlunit-core/src/test/java/org/xmlunit/builder/InputTest.java b/xmlunit-core/src/test/java/org/xmlunit/builder/InputTest.java
+index 83ff38a..fac270d 100644
+--- a/xmlunit-core/src/test/java/org/xmlunit/builder/InputTest.java
++++ b/xmlunit-core/src/test/java/org/xmlunit/builder/InputTest.java
+@@ -31,7 +31,6 @@ import org.w3c.dom.Document;
+ import org.xmlunit.NullNode;
+ import org.xmlunit.TestResources;
+ import org.xmlunit.XMLUnitException;
+-import org.xmlunit.builder.jaxb.ComplexNode;
+ import org.xmlunit.util.Convert;
+ import org.xmlunit.xpath.JAXPXPathEngine;
+ 
+@@ -148,10 +147,6 @@ public class InputTest {
+         allIsWellFor(s, "furry");
+     }
+ 
+-    @Test public void shouldParseJaxbObject() throws Exception {
+-        allIsWellFor(Input.fromJaxb(new ComplexNode()).build(), "complexNode");
+-    }
+-
+     @Test public void shouldParseUnknownToSource() throws Exception {
+         // from Source
+         allIsWellFor(Input.from(Input.fromByteArray(readTestFile()).build()).build());
+@@ -169,8 +164,6 @@ public class InputTest {
+         allIsWellFor(Input.from(new URI("file:" + TestResources.ANIMAL_FILE)).build());
+         // from URL
+         allIsWellFor(Input.from(new URL("file:" + TestResources.ANIMAL_FILE)).build());
+-        // from Jaxb-Object
+-        allIsWellFor(Input.from(new ComplexNode()).build(), "complexNode");
+         // from InputStream
+         FileInputStream is = null;
+         try {
+-- 
+2.21.0
+

--- a/project/guava.xml
+++ b/project/guava.xml
@@ -41,7 +41,12 @@
           [/replaceregexp]
         </run>
       </ant>
-      <compiler/>
+      <compiler>
+        <excludeSourceClass>com/google/common/cache/Striped64</excludeSourceClass>
+        <excludeSourceClass>com/google/common/cache/LongAdder</excludeSourceClass>
+        <excludeSourceClass>com/google/common/hash/Striped64</excludeSourceClass>
+        <excludeSourceClass>com/google/common/hash/LongAdder</excludeSourceClass>
+      </compiler>
     </build>
   </module>
 </project>

--- a/project/objenesis.xml
+++ b/project/objenesis.xml
@@ -3,6 +3,8 @@
     <build>
       <compiler>
         <addSourceRoot>main/src/main/java</addSourceRoot>
+        <excludeSourceClass>org/objenesis/instantiator/sun/UnsafeFactoryInstantiator</excludeSourceClass>
+        <excludeSourceClass>org/objenesis/instantiator/util/UnsafeUtils</excludeSourceClass>
       </compiler>
     </build>
   </module>

--- a/project/xmlunit.xml
+++ b/project/xmlunit.xml
@@ -8,6 +8,7 @@
         <addSourceRoot>xmlunit-core/src/main/java</addSourceRoot>
         <addSourceRoot>xmlunit-matchers/src/main/java</addSourceRoot>
         <addSourceRoot>xmlunit-assertj/src/main/java</addSourceRoot>
+        <excludeSourceClass>org/xmlunit/builder/JaxbBuilder</excludeSourceClass>
       </compiler>
     </build>
   </module>


### PR DESCRIPTION
Everything is built with OpenJDK 11, passing `--release 8` to compiler when necessary.
Usage of JAXB and obsolete `sun.misc.Unsafe` is patched out.
Fixes #11