### PR TITLE
Always refresh git remotes during clone

### DIFF
--- a/downstream.sh
+++ b/downstream.sh
@@ -49,6 +49,7 @@ function clone()
 {
     if [[ "$type" = git ]]; then
         if [[ -d "upstream/$p.git" ]]; then
+            $git -C "upstream/$p.git" remote set-url origin "$url"
             $git -C "upstream/$p.git" fetch
         else
             $git clone --mirror "$url" "upstream/$p.git"


### PR DESCRIPTION
In case cached git repos are found, clone command should work even
when remote git URL changes. This is done by removing and re-adding
git remote with up-to-date URL.