### PR TITLE
Update DistCommand.java

### DIFF
--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -17,12 +17,12 @@
 FROM registry.fedoraproject.org/fedora:rawhide
 
 ENV LC_ALL=C.utf8 \
-    JAVA_HOME=/usr/lib/jvm/java-17-openjdk
+    JAVA_HOME=/usr/lib/jvm/java-17
 
 RUN dnf -y update \
  && dnf -y install git-core \
                    unzip \
-                   java-17-openjdk-devel \
+                   java-17-devel \
                    byaccj \
                    gcc \
                    rpm-devel \

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ that allow you to control the shape and the location of binary
 distribution:
 
 * `-javaCmdPath` points to `java` executable, for use in launcher
-  shebangs (defaults to `/usr/lib/jvm/java-17-openjdk`).
+  shebangs (defaults to `/usr/lib/jvm/java-17`).
 
 * `-installRoot` specifies directory into which distribution will be
   installed (equivalent to `$RPM_BUILD_ROOT` in RPM build), by default

--- a/mbi.sh
+++ b/mbi.sh
@@ -18,7 +18,7 @@
 
 set -eu
 
-JAVA_HOME=${JAVA_HOME:-/usr/lib/jvm/java-17-openjdk}
+JAVA_HOME=${JAVA_HOME:-/usr/lib/jvm/java-17}
 
 mkdir -p build/mbi-launcher/classes
 $JAVA_HOME/bin/javac -g -d build/mbi-launcher/classes $(find mbi/core -name *.java)

--- a/mbi/core/src/org/fedoraproject/mbi/dist/DistCommand.java
+++ b/mbi/core/src/org/fedoraproject/mbi/dist/DistCommand.java
@@ -42,7 +42,7 @@ public class DistCommand
         Path workDir = reactor.getTargetDir( distModule ).resolve( "dist-work" );
         Util.delete( workDir );
 
-        String javaCmdPath = getOption( "javaCmdPath", "/usr/lib/jvm/java-17-openjdk/bin/java" );
+        String javaCmdPath = getOption( "javaCmdPath", "/usr/lib/jvm/java-17/bin/java" );
         String basePackageName = getOption( "basePackageName", "mbi" );
         String installRoot = getOption( "installRoot", "/" );
         String mavenHomePath = getOption( "mavenHomePath", "/opt/mbi/maven" );

--- a/patches/maven/0004-Bind-to-OpenJDK-17-for-runtime.patch
+++ b/patches/maven/0004-Bind-to-OpenJDK-17-for-runtime.patch
@@ -31,7 +31,7 @@ index dfa384b8e..2e9f10da0 100755
 -  fi
 -
 -fi
-+export JAVA_HOME=/usr/lib/jvm/java-17-openjdk
++export JAVA_HOME=/usr/lib/jvm/java-17
  
  # OS specific support. $var _must_ be set to either true or false.
  cygwin=false;


### PR DESCRIPTION
Adapted to more JDK distributions like konaJDK because other JDK and OpenJDK also have /usr/lib/jvm/java-17 directory so this patch can adds more compatibility
Or there will be %mvn_install error in xmvn-installer

like OpenCloudOS, its default JDK is konaJDK (a JDK from Tencent) ,it have /usr/lib/jvm/java-17 and /usr/lib/jvm/java-17-konajdk but not /usr/lib/jvm/java-17-openjdk