### PR TITLE
Fix maven-enforcer

### DIFF
--- a/mbi/dist/metadata.txt
+++ b/mbi/dist/metadata.txt
@@ -400,27 +400,16 @@ MOD maven-embedder
     DEP org.fusesource.jansi jansi
 MOD maven-enforcer
   ART org.apache.maven.enforcer enforcer-rules
-    DEP org.apache.maven maven-artifact
-    DEP org.apache.maven maven-plugin-api
-    DEP org.apache.maven maven-core
-    DEP org.apache.maven.shared maven-common-artifact-filters
     DEP org.codehaus.plexus plexus-utils
     DEP org.apache.commons commons-lang3
     DEP commons-codec commons-codec
     DEP commons-io commons-io
     DEP org.apache.maven.enforcer enforcer-api
-    DEP org.apache.maven.shared maven-dependency-tree
     DEP org.apache.maven.resolver maven-resolver-util
-    DEP org.apache.maven maven-compat
   ART org.apache.maven.plugins maven-enforcer-plugin
-    DEP org.apache.maven maven-artifact
-    DEP org.apache.maven maven-plugin-api
-    DEP org.apache.maven maven-core
-    DEP org.codehaus.plexus plexus-utils
     DEP org.apache.maven.enforcer enforcer-api
     DEP org.apache.maven.enforcer enforcer-rules
   ART org.apache.maven.enforcer enforcer-api
-    DEP org.apache.maven maven-plugin-api
 MOD maven-file-management
   ART org.apache.maven.shared file-management
     DEP org.apache.maven maven-plugin-api

--- a/project/maven-enforcer.xml
+++ b/project/maven-enforcer.xml
@@ -31,6 +31,7 @@
         <addSourceRoot>maven-enforcer-plugin/src/main/java</addSourceRoot>
         <excludeSourceClass>EvaluateBeanshell</excludeSourceClass>
       </compiler>
+      <cdc/>
       <pdc>
         <artifactId>maven-enforcer-plugin</artifactId>
       </pdc>


### PR DESCRIPTION
Fixes maven-enforcer-plugin crash:

```
[ERROR] 1) No implementation for EnforcerRuleManager was bound.
[ERROR]   while locating EnforceMojo
[ERROR]   at ClassRealm[plugin>org.apache.maven.plugins:maven-enforcer-plugin:3.0.0, parent: ClassLoaders$AppClassLoader@5cb0d902]
[ERROR]       \_ installed by: WireModule -> PlexusBindingModule
[ERROR]   while locating Mojo annotated with @Named("org.apache.maven.plugins:maven-enforcer-plugin:3.3.0.MBI:enforce")
```