### PR TITLE
Re-add dependencies required by mbi-pdc to work

### DIFF
--- a/mbi/pdc/src/org/fedoraproject/mbi/tool/pdc/PdcTool.java
+++ b/mbi/pdc/src/org/fedoraproject/mbi/tool/pdc/PdcTool.java
@@ -101,6 +101,11 @@ public class PdcTool
             container.dispose();
         }
 
+        if ( pluginDescriptor.getMojos().isEmpty() )
+        {
+            throw new RuntimeException( "No MOJOs were discovered by PDC for module " + getModule().getName() );
+        }
+
         PluginDescriptorFilesGenerator generator = new PluginDescriptorFilesGenerator();
         generator.execute( getClassesDir().resolve( "META-INF/maven" ).toFile(), request );
     }

--- a/project/mbi.xml
+++ b/project/mbi.xml
@@ -87,6 +87,7 @@
     <dependency>plexus-utils</dependency>
     <dependency>sisu-plexus</dependency>
     <dependency>plexus-classworlds</dependency>
+    <dependency>maven-resolver</dependency>
     <dependency>sisu-inject</dependency>
     <dependency>guice</dependency>
     <dependency>injection-api</dependency>
@@ -95,14 +96,21 @@
     <dependency>plexus-interpolation</dependency>
     <dependency>slf4j</dependency>
     <dependency>commons-lang</dependency>
+    <dependency>asm</dependency>
+    <dependency>asm-util</dependency>
     <dependency>maven-core</dependency>
     <dependency>maven-plugin-api</dependency>
     <dependency>maven-model</dependency>
     <dependency>maven-model-builder</dependency>
     <dependency>maven-resolver-provider</dependency>
     <dependency>maven-builder-support</dependency>
+    <dependency>maven-repository-metadata</dependency>
     <dependency>maven-artifact</dependency>
+    <dependency>maven-settings</dependency>
+    <dependency>qdox</dependency>
+    <dependency>plexus-archiver</dependency>
     <dependency>plexus-io</dependency>
+    <dependency>jsoup</dependency>
     <build>
       <compiler>
         <addSourceRoot>src</addSourceRoot>


### PR DESCRIPTION
Also make PDC fail if no MOJOs were discrovered to protect against dependency removal in the future.