### PR TITLE
Add command for generating licening breakdown

### DIFF
--- a/mbi/core/src/org/fedoraproject/mbi/Main.java
+++ b/mbi/core/src/org/fedoraproject/mbi/Main.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.fedoraproject.mbi.build.BuildCommand;
 import org.fedoraproject.mbi.dist.DistCommand;
+import org.fedoraproject.mbi.licensing.LicensingCommand;
 
 /**
  * @author Mikolaj Izdebski
@@ -32,6 +33,7 @@ public class Main
         COMMANDS.put( "build", BuildCommand.class );
         COMMANDS.put( "dist", DistCommand.class );
         COMMANDS.put( "graph", GraphCommand.class );
+        COMMANDS.put( "licensing", LicensingCommand.class );
     }
 
     public static void main( String[] args )
@@ -44,6 +46,7 @@ public class Main
             System.err.println( "  - build - build and assemble stage 3" );
             System.err.println( "  - dist - create stage 3 distribution" );
             System.err.println( "  - graph - output project dependency graph" );
+            System.err.println( "  - licensing - print licensing information" );
             System.exit( 1 );
         }
 

--- a/mbi/core/src/org/fedoraproject/mbi/licensing/AST.java
+++ b/mbi/core/src/org/fedoraproject/mbi/licensing/AST.java
@@ -1,0 +1,37 @@
+/*-
+ * Copyright (c) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fedoraproject.mbi.licensing;
+
+/**
+ * SPDX expression AST node.
+ * 
+ * @author Mikolaj Izdebski
+ */
+abstract class AST
+    implements Comparable<AST>
+{
+    @Override
+    public boolean equals( Object other )
+    {
+        return other instanceof AST && other.toString().equals( toString() );
+    }
+
+    @Override
+    public int compareTo( AST other )
+    {
+        return toString().compareTo( other.toString() );
+    }
+}

--- a/mbi/core/src/org/fedoraproject/mbi/licensing/Atom.java
+++ b/mbi/core/src/org/fedoraproject/mbi/licensing/Atom.java
@@ -1,0 +1,38 @@
+/*-
+ * Copyright (c) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fedoraproject.mbi.licensing;
+
+/**
+ * SPDX atom AST node.
+ * 
+ * @author Mikolaj Izdebski
+ */
+class Atom
+    extends AST
+{
+    private final String tag;
+
+    Atom( String tag )
+    {
+        this.tag = tag;
+    }
+
+    @Override
+    public String toString()
+    {
+        return tag;
+    }
+}

--- a/mbi/core/src/org/fedoraproject/mbi/licensing/LicensingCommand.java
+++ b/mbi/core/src/org/fedoraproject/mbi/licensing/LicensingCommand.java
@@ -1,0 +1,53 @@
+/*-
+ * Copyright (c) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fedoraproject.mbi.licensing;
+
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+import org.fedoraproject.mbi.Command;
+import org.fedoraproject.mbi.Reactor;
+
+/**
+ * @author Mikolaj Izdebski
+ */
+public class LicensingCommand
+    extends Command
+{
+    @Override
+    public void run()
+        throws Exception
+    {
+        Reactor reactor = Reactor.defaultReactor();
+
+        Map<String, String> tags = new TreeMap<>();
+        for ( var project : reactor.getProjects() )
+        {
+            tags.put( project.getName(), project.getLicensing().getTag() );
+        }
+        String combined = "(" + tags.values().stream().collect( Collectors.joining( ") AND (" ) ) + ")";
+
+        print( "# Licensing breakdown: " );
+        for ( Entry<String, String> entry : tags.entrySet() )
+        {
+            print( "#    " + entry.getKey() + " has license: " + new SPDX( entry.getValue() ) );
+        }
+        print( "# Therefore combined license is: " );
+        print( "License:        " + new SPDX( combined ) );
+    }
+}

--- a/mbi/core/src/org/fedoraproject/mbi/licensing/Operator.java
+++ b/mbi/core/src/org/fedoraproject/mbi/licensing/Operator.java
@@ -1,0 +1,72 @@
+/*-
+ * Copyright (c) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fedoraproject.mbi.licensing;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+/**
+ * SPDX operator AST node.
+ * 
+ * @author Mikolaj Izdebski
+ */
+class Operator
+    extends AST
+{
+    private final int precedence;
+
+    private final String lexem;
+
+    private Set<AST> children = new LinkedHashSet<>();
+
+    public Operator( String lexem, int precedence, AST... args )
+    {
+        this.precedence = precedence;
+        this.lexem = lexem;
+        for ( AST arg : args )
+        {
+            if ( arg instanceof Operator && ( (Operator) arg ).precedence == precedence )
+            {
+                children.addAll( ( (Operator) arg ).children );
+            }
+            else
+            {
+                children.add( arg );
+            }
+        }
+        if ( precedence > 1 )
+        {
+            children = new TreeSet<>( children );
+        }
+    }
+
+    private String enclose( AST expr )
+    {
+        if ( expr instanceof Operator && ( (Operator) expr ).precedence > precedence )
+        {
+            return "(" + expr.toString() + ")";
+        }
+        return expr.toString();
+    }
+
+    @Override
+    public String toString()
+    {
+        return children.stream().map( this::enclose ).collect( Collectors.joining( lexem ) );
+    }
+}

--- a/mbi/core/src/org/fedoraproject/mbi/licensing/SPDX.java
+++ b/mbi/core/src/org/fedoraproject/mbi/licensing/SPDX.java
@@ -1,0 +1,136 @@
+/*-
+ * Copyright (c) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fedoraproject.mbi.licensing;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * SPDX expression parser.
+ * 
+ * @author Mikolaj Izdebski
+ */
+class SPDX
+{
+    private static final Pattern ID_REGEX = Pattern.compile( "([a-zA-Z0-9.-]+).*" );
+
+    private final String rawExpression;
+
+    private int parserPos;
+
+    private final String niceExpression;
+
+    public SPDX( String rawExpression )
+    {
+        this.rawExpression = rawExpression;
+        niceExpression = parseExpression().toString();
+
+    }
+
+    private void parseError( String msg )
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.append( "Syntax error - " + msg + "\n" );
+        sb.append( "  SPDX expression: \"" + rawExpression + "\"\n" );
+        sb.append( "  Location: here ---" + new String( "-" ).repeat( parserPos ) + "^" );
+        throw new RuntimeException( sb.toString() );
+    }
+
+    private void parseEof()
+    {
+        if ( parserPos != rawExpression.length() )
+        {
+            parseError( "Expected EOF" );
+        }
+    }
+
+    private boolean matches( String op )
+    {
+        if ( rawExpression.substring( parserPos ).startsWith( op ) )
+        {
+            parserPos += op.length();
+            return true;
+        }
+        return false;
+    }
+
+    private AST parseAtom()
+    {
+        Matcher matcher = ID_REGEX.matcher( rawExpression.substring( parserPos ) );
+        if ( !matcher.matches() )
+        {
+            parseError( "Expected identifier" );
+        }
+        String tag = matcher.group( 1 );
+        parserPos += tag.length();
+        return new Atom( tag );
+    }
+
+    private AST parsePrimary()
+    {
+        if ( matches( "(" ) )
+        {
+            AST inner = parseUnion();
+            if ( !matches( ")" ) )
+            {
+                parseError( "Unclosed parenthesis" );
+            }
+            return inner;
+        }
+        AST lhs = parseAtom();
+        if ( matches( " WITH " ) )
+        {
+            AST rhs = parseAtom();
+            return new Operator( " WITH ", 1, lhs, rhs );
+        }
+        return lhs;
+    }
+
+    private AST parseIntersection()
+    {
+        AST lhs = parsePrimary();
+        if ( matches( " AND " ) )
+        {
+            AST rhs = parseIntersection();
+            return new Operator( " AND ", 2, lhs, rhs );
+        }
+        return lhs;
+    }
+
+    private AST parseUnion()
+    {
+        AST lhs = parseIntersection();
+        if ( matches( " OR " ) )
+        {
+            AST rhs = parseUnion();
+            return new Operator( " OR ", 3, lhs, rhs );
+        }
+        return lhs;
+    }
+
+    private AST parseExpression()
+    {
+        AST expr = parseUnion();
+        parseEof();
+        return expr;
+    }
+
+    @Override
+    public String toString()
+    {
+        return niceExpression;
+    }
+}


### PR DESCRIPTION
Produces the following output:

```
# Licensing breakdown: 
#    ant has license: Apache-2.0
#    aopalliance has license: LicenseRef-Fedora-Public-Domain
#    apache-pom has license: Apache-2.0
#    apiguardian has license: Apache-2.0
#    asm has license: BSD-3-Clause
#    assertj-core has license: Apache-2.0
#    bnd has license: Apache-2.0 OR EPL-2.0
#    build-helper-maven-plugin has license: MIT
#    byte-buddy has license: Apache-2.0
#    cdi has license: Apache-2.0
#    cglib has license: Apache-2.0 AND BSD-3-Clause
#    common-annotations-api has license: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
#    commons-beanutils has license: Apache-2.0
#    commons-cli has license: Apache-2.0
#    commons-codec has license: Apache-2.0
#    commons-collections has license: Apache-2.0
#    commons-compress has license: Apache-2.0
#    commons-io has license: Apache-2.0
#    commons-jxpath has license: Apache-2.0
#    commons-lang has license: Apache-2.0
#    commons-logging has license: Apache-2.0
#    commons-parent-pom has license: Apache-2.0
#    cup has license: SMLNJ
#    disruptor has license: Apache-2.0
#    easymock has license: Apache-2.0
#    extra-enforcer-rules has license: Apache-2.0
#    felix-parent-pom has license: Apache-2.0
#    felix-utils has license: Apache-2.0
#    fusesource-pom has license: Apache-2.0
#    guava has license: Apache-2.0 AND CC0-1.0
#    guice has license: Apache-2.0
#    hamcrest has license: BSD-3-Clause
#    httpcomponents-client has license: Apache-2.0
#    httpcomponents-core has license: Apache-2.0
#    httpcomponents-parent-pom has license: Apache-2.0
#    injection-api has license: Apache-2.0
#    jaf-api has license: BSD-3-Clause
#    jansi has license: Apache-2.0
#    javacc has license: BSD-2-Clause AND BSD-3-Clause
#    javacc-maven-plugin has license: Apache-2.0
#    jcommander has license: Apache-2.0
#    jctools has license: Apache-2.0
#    jdom has license: Saxpath
#    jdom2 has license: Saxpath
#    jflex has license: BSD-3-Clause
#    jsoup has license: MIT
#    jsr-305 has license: BSD-3-Clause AND CC-BY-2.5
#    junit4 has license: EPL-1.0
#    junit5 has license: EPL-2.0
#    log4j has license: Apache-2.0
#    mail-api has license: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
#    maven has license: Apache-2.0 AND MIT
#    maven-antrun-plugin has license: Apache-2.0
#    maven-apache-resources has license: Apache-2.0
#    maven-archiver has license: Apache-2.0
#    maven-artifact-transfer has license: Apache-2.0
#    maven-assembly-plugin has license: Apache-2.0
#    maven-bundle-plugin has license: Apache-2.0
#    maven-common-artifact-filters has license: Apache-2.0
#    maven-compiler-plugin has license: Apache-2.0
#    maven-dependency-analyzer has license: Apache-2.0
#    maven-dependency-plugin has license: Apache-2.0
#    maven-dependency-tree has license: Apache-2.0
#    maven-enforcer has license: Apache-2.0
#    maven-file-management has license: Apache-2.0
#    maven-filtering has license: Apache-2.0
#    maven-jar-plugin has license: Apache-2.0
#    maven-parent-pom has license: Apache-2.0
#    maven-plugin-testing has license: Apache-2.0
#    maven-plugin-tools has license: Apache-2.0
#    maven-remote-resources-plugin has license: Apache-2.0
#    maven-resolver has license: Apache-2.0
#    maven-resources-plugin has license: Apache-2.0
#    maven-shared-incremental has license: Apache-2.0
#    maven-shared-io has license: Apache-2.0
#    maven-shared-utils has license: Apache-2.0
#    maven-source-plugin has license: Apache-2.0
#    maven-surefire has license: Apache-2.0 AND CPL-1.0
#    maven-verifier has license: Apache-2.0
#    maven-wagon has license: Apache-2.0
#    mbi has license: Apache-2.0
#    mockito has license: MIT
#    modello has license: Apache-2.0 AND MIT AND Plexus
#    modulemaker-maven-plugin has license: Apache-2.0
#    mojo-parent-pom has license: Apache-2.0
#    objenesis has license: Apache-2.0
#    opentest4j has license: Apache-2.0
#    osgi-annotation has license: Apache-2.0
#    osgi-cmpn has license: Apache-2.0
#    osgi-core has license: Apache-2.0
#    plexus-archiver has license: Apache-2.0
#    plexus-build-api has license: Apache-2.0
#    plexus-cipher has license: Apache-2.0
#    plexus-classworlds has license: Apache-2.0 AND Plexus
#    plexus-compiler has license: Apache-2.0 AND MIT
#    plexus-components-pom has license: Apache-2.0
#    plexus-containers has license: Apache-2.0 AND MIT AND xpp
#    plexus-interpolation has license: Apache-1.1 AND Apache-2.0 AND MIT
#    plexus-io has license: Apache-2.0
#    plexus-languages has license: Apache-2.0
#    plexus-pom has license: Apache-2.0
#    plexus-resources has license: Apache-2.0 AND MIT
#    plexus-sec-dispatcher has license: Apache-2.0
#    plexus-utils has license: Apache-1.1 AND Apache-2.0 AND BSD-3-Clause AND LicenseRef-Fedora-Public-Domain AND xpp
#    qdox has license: Apache-2.0
#    servlet-api has license: Apache-2.0 AND (EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0)
#    sisu-inject has license: BSD-3-Clause AND EPL-1.0
#    sisu-mojos has license: EPL-1.0
#    sisu-plexus has license: BSD-3-Clause AND EPL-1.0
#    slf4j has license: Apache-2.0 AND MIT
#    testng has license: Apache-2.0
#    univocity-parsers has license: Apache-2.0
#    velocity-engine has license: Apache-2.0
#    xbean has license: Apache-2.0
#    xmlunit has license: Apache-2.0
#    xmvn has license: Apache-2.0
#    xmvn-generator has license: Apache-2.0
#    xz-java has license: LicenseRef-Fedora-Public-Domain
# Therefore combined license is: 
License:        Apache-1.1 AND Apache-2.0 AND (Apache-2.0 OR EPL-2.0) AND BSD-2-Clause AND BSD-3-Clause AND CC-BY-2.5 AND CC0-1.0 AND CPL-1.0 AND EPL-1.0 AND EPL-2.0 AND (EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0) AND LicenseRef-Fedora-Public-Domain AND MIT AND Plexus AND SMLNJ AND Saxpath AND xpp
```

Closes #100