### PR TITLE
Switch build to Java 21

### DIFF
--- a/mbi.sh
+++ b/mbi.sh
@@ -18,7 +18,7 @@
 
 set -eu
 
-JAVA_HOME=${JAVA_HOME:-/usr/lib/jvm/java-17}
+JAVA_HOME=${JAVA_HOME:-/usr/lib/jvm/java-21}
 
 mkdir -p build/mbi-launcher/classes
 $JAVA_HOME/bin/javac -g -d build/mbi-launcher/classes $(find mbi/core -name \*.java)

--- a/mbi/ant/src/org/fedoraproject/mbi/tool/ant/AntTool.java
+++ b/mbi/ant/src/org/fedoraproject/mbi/tool/ant/AntTool.java
@@ -26,11 +26,13 @@ import java.util.Map;
 import org.apache.tools.ant.ExitException;
 import org.apache.tools.ant.Main;
 import org.fedoraproject.mbi.tool.Instruction;
+import org.fedoraproject.mbi.tool.ThreadUnsafe;
 import org.fedoraproject.mbi.tool.Tool;
 
 /**
  * @author Mikolaj Izdebski
  */
+@ThreadUnsafe
 public class AntTool
     extends Tool
 {

--- a/mbi/ant/src/org/fedoraproject/mbi/tool/ant/AntTool.java
+++ b/mbi/ant/src/org/fedoraproject/mbi/tool/ant/AntTool.java
@@ -68,7 +68,6 @@ public class AntTool
         Path classesDir = getReactor().getClassesDir( getModule() );
         Path generatedSourcesDir = getReactor().getGeneratedSourcesDir( getModule() );
         Path buildFile = getReactor().getTargetDir( getModule() ).resolve( "ant-run.xml" );
-        Path logFile = getReactor().getTargetDir( getModule() ).resolve( "ant-run.log" );
         Files.createDirectories( buildFile.getParent() );
 
         try ( OutputStream os = Files.newOutputStream( buildFile ); PrintStream ps = new PrintStream( os ) )
@@ -87,12 +86,8 @@ public class AntTool
         }
 
         Exception exception = null;
-        PrintStream out = System.out;
-        PrintStream err = System.err;
-        try ( PrintStream log = new PrintStream( Files.newOutputStream( logFile ) ) )
+        try
         {
-            System.setOut( log );
-            System.setErr( log );
             new Main()
             {
                 protected void exit( int exitCode )
@@ -108,15 +103,9 @@ public class AntTool
                 exception = e;
             }
         }
-        finally
-        {
-            System.setOut( out );
-            System.setErr( err );
-        }
 
         if ( exception != null )
         {
-            System.err.print( Files.readString( logFile ) );
             throw exception;
         }
     }

--- a/mbi/core/src/org/fedoraproject/mbi/build/BuildExecutor.java
+++ b/mbi/core/src/org/fedoraproject/mbi/build/BuildExecutor.java
@@ -86,7 +86,6 @@ class BuildExecutor
             {
                 var step = completableSteps.remove();
                 completingSteps++;
-                System.err.println( step.getModule().getName() + ": " + step.getToolName() );
                 return step;
             }
             try

--- a/mbi/core/src/org/fedoraproject/mbi/tool/ThreadUnsafe.java
+++ b/mbi/core/src/org/fedoraproject/mbi/tool/ThreadUnsafe.java
@@ -1,0 +1,28 @@
+/*-
+ * Copyright (c) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fedoraproject.mbi.tool;
+
+import static java.lang.annotation.ElementType.TYPE;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target( TYPE )
+@Retention( RetentionPolicy.RUNTIME )
+public @interface ThreadUnsafe
+{
+}

--- a/mbi/javacc/src/org/fedoraproject/mbi/tool/javacc/JavaccTool.java
+++ b/mbi/javacc/src/org/fedoraproject/mbi/tool/javacc/JavaccTool.java
@@ -1,0 +1,74 @@
+/*-
+ * Copyright (c) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fedoraproject.mbi.tool.javacc;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.fedoraproject.mbi.tool.Instruction;
+import org.fedoraproject.mbi.tool.ThreadUnsafe;
+import org.fedoraproject.mbi.tool.Tool;
+import org.javacc.jjtree.JJTree;
+
+/**
+ * @author Mikolaj Izdebski
+ */
+@ThreadUnsafe
+public class JavaccTool
+    extends Tool
+{
+    private boolean runJjtree;
+
+    private List<String> args = new ArrayList<>();
+
+    @Instruction
+    public void jjtree( String dummy )
+    {
+        runJjtree = true;
+    }
+
+    @Instruction
+    public void arg( String arg )
+    {
+        arg = arg.replaceAll( "\\$\\{basedir}", getSourceRootDir().toString() );
+        arg = arg.replaceAll( "\\$\\{generatedSources}", getGeneratedSourcesDir().toString() );
+        args.add( arg );
+    }
+
+    @Override
+    public void execute()
+        throws Exception
+    {
+        String[] argsArray = args.toArray( new String[args.size()] );
+        if ( runJjtree )
+        {
+            JJTree jjtree = new JJTree();
+            int result = jjtree.main( argsArray );
+            if ( result != 0 )
+            {
+                throw new Exception( "jjtree failed with exit code " + result );
+            }
+        }
+        else
+        {
+            int result = org.javacc.parser.Main.mainProgram( argsArray );
+            if ( result != 0 )
+            {
+                throw new Exception( "javacc failed with exit code " + result );
+            }
+        }
+    }
+}

--- a/project/cup.properties
+++ b/project/cup.properties
@@ -1,3 +1,3 @@
-url=https://versioncontrolseidl.in.tum.de/parsergenerators/cup.git
+url=https://github.com/mizdebsk/cup.git
 ref=6bd4cd5
 version=0.11b

--- a/project/javaparser.xml
+++ b/project/javaparser.xml
@@ -4,17 +4,12 @@
   </licensing>
   <module>
     <subDir>javaparser-core</subDir>
-    <dependency>javacc</dependency>
     <dependency>guava</dependency>
     <build>
-      <ant>
-        <run>
-          [java classname="javacc" failonerror="true"]
-            [arg value="-OUTPUT_DIRECTORY=${generatedSources}/com/github/javaparser"/]
-            [arg value="${basedir}/src/main/javacc/java.jj"/]
-          [/java]
-        </run>
-      </ant>
+      <javacc>
+        <arg>-OUTPUT_DIRECTORY=${generatedSources}/com/github/javaparser</arg>
+        <arg>${basedir}/src/main/javacc/java.jj</arg>
+      </javacc>
       <compiler>
         <addSourceRoot>src/main/java</addSourceRoot>
         <addSourceRoot>src/main/java-templates</addSourceRoot>

--- a/project/mbi.xml
+++ b/project/mbi.xml
@@ -152,4 +152,16 @@
       </compiler>
     </build>
   </module>
+  <module>
+    <name>mbi-javacc</name>
+    <subDir>javacc</subDir>
+    <dependency>mbi-core</dependency>
+    <dependency>javacc</dependency>
+    <build>
+      <compiler>
+        <release>11</release>
+        <addSourceRoot>src</addSourceRoot>
+      </compiler>
+    </build>
+  </module>
 </project>

--- a/project/velocity-engine.xml
+++ b/project/velocity-engine.xml
@@ -5,7 +5,6 @@
   </licensing>
   <module>
     <subDir>velocity-engine-core</subDir>
-    <dependency>javacc</dependency>
     <dependency>commons-io</dependency>
     <dependency>commons-lang</dependency>
     <dependency>slf4j</dependency>
@@ -22,21 +21,22 @@
           [replace file="${generatedSources}/Parser.jjt" token="$${parser.char.at}" value="@"/]
           [replace file="${generatedSources}/Parser.jjt" token="$${parser.char.dollar}" value="$"/]
           [replace file="${generatedSources}/Parser.jjt" token="$${parser.char.hash}" value="#"/]
-          [java classname="jjtree" failonerror="true"]
-            [arg value="-OUTPUT_DIRECTORY=${generatedSources}/org/apache/velocity/runtime/parser/node"/]
-            [arg value="-NOBUILD_NODE_FILES"/]
-            [arg value="-NOVISITOR"/]
-            [arg value="-NODE_USES_PARSER"/]
-            [arg value="-NODE_PACKAGE=org.apache.velocity.runtime.parser.node"/]
-            [arg value="${generatedSources}/Parser.jjt"/]
-          [/java]
-          [java classname="javacc" failonerror="true"]
-            [arg value="-OUTPUT_DIRECTORY=${generatedSources}/org/apache/velocity/runtime/parser"/]
-            [arg value="-TOKEN_MANAGER_USES_PARSER"/]
-            [arg value="${generatedSources}/org/apache/velocity/runtime/parser/node/Parser.jj"/]
-          [/java]
         </run>
       </ant>
+      <javacc>
+        <arg>-OUTPUT_DIRECTORY=${generatedSources}/org/apache/velocity/runtime/parser/node</arg>
+        <arg>-NOBUILD_NODE_FILES</arg>
+        <arg>-NOVISITOR</arg>
+        <arg>-NODE_USES_PARSER</arg>
+        <arg>-NODE_PACKAGE=org.apache.velocity.runtime.parser.node</arg>
+        <arg>${generatedSources}/Parser.jjt</arg>
+        <jjtree/>
+      </javacc>
+      <javacc>
+        <arg>-OUTPUT_DIRECTORY=${generatedSources}/org/apache/velocity/runtime/parser</arg>
+        <arg>-TOKEN_MANAGER_USES_PARSER</arg>
+        <arg>${generatedSources}/org/apache/velocity/runtime/parser/node/Parser.jj</arg>
+      </javacc>
       <compiler>
         <addSourceRoot>src/main/java</addSourceRoot>
         <addSourceRoot>src/main/java-templates</addSourceRoot>


### PR DESCRIPTION
Fix build issues with Java 21 and switch to it by default.

Currently javacc is executed through Ant.
Ant calls javacc main() methods, but inhibits System.exit() with reliance on Java security manager.
Ant 1.10.14 contains an important change wherein it no longer uses or sets Java SecurityManager when running on Java versions 18 and higher. See https://ant.apache.org/antnews.html
This means that on on Java <= 17 security manager is used to disallow calling System.exit(),
while on Java >= 18 security manager is not used, and System.exit() can be called during build.

The PR avoids the issue by invoking javacc directly, without using Ant.