### PR TITLE
Add several projects needed to build Maven 4

### DIFF
--- a/patches/gson/0001-Remove-dependency-on-Error-Prone-Annotations.patch
+++ b/patches/gson/0001-Remove-dependency-on-Error-Prone-Annotations.patch
@@ -1,0 +1,27 @@
+From 691d6744a88855ce8215a492c967ebc04492b2fc Mon Sep 17 00:00:00 2001
+From: Mikolaj Izdebski <mizdebsk@redhat.com>
+Date: Sun, 2 Feb 2025 08:05:46 +0100
+Subject: [PATCH] Remove dependency on Error Prone Annotations
+
+Forwarded: not-needed
+---
+ gson/src/main/java/module-info.java | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/gson/src/main/java/module-info.java b/gson/src/main/java/module-info.java
+index 66926396..300a007e 100644
+--- a/gson/src/main/java/module-info.java
++++ b/gson/src/main/java/module-info.java
+@@ -25,9 +25,6 @@ module com.google.gson {
+   exports com.google.gson.reflect;
+   exports com.google.gson.stream;
+ 
+-  // Optional dependency on Error Prone Annotations
+-  requires static com.google.errorprone.annotations;
+-
+   // Optional dependency on java.sql
+   requires static java.sql;
+ 
+-- 
+2.48.1
+

--- a/project/gson.properties
+++ b/project/gson.properties
@@ -1,0 +1,4 @@
+url=https://github.com/google/gson
+ref=gson-parent-@.@.@
+version=2.12.1
+rpm_name=google-gson

--- a/project/gson.xml
+++ b/project/gson.xml
@@ -1,0 +1,17 @@
+<project>
+  <licensing>
+    <tag>Apache-2.0</tag>
+  </licensing>
+  <module>
+    <build>
+      <jurand>
+        <source>gson/src/main/java</source>
+        <pattern>^com.google.errorprone.annotations.</pattern>
+      </jurand>
+      <compiler>
+	<release>17</release>
+        <addSourceRoot>gson/src/main/java-templates</addSourceRoot>
+      </compiler>
+    </build>
+  </module>
+</project>

--- a/project/jline3.properties
+++ b/project/jline3.properties
@@ -1,0 +1,4 @@
+url=https://github.com/jline/jline3
+ref=@.@.@
+version=3.28.1
+#rpm_name=

--- a/project/jline3.xml
+++ b/project/jline3.xml
@@ -1,0 +1,45 @@
+<project>
+  <licensing>
+    <tag>BSD-3-Clause</tag>
+    <file>LICENSE.txt</file>
+  </licensing>
+  <module>
+    <dependency>jsr-305</dependency>
+    <build>
+      <compiler>
+        <addSourceRoot>builtins/src/main/java</addSourceRoot>
+        <addSourceRoot>console-ui/src/main/java</addSourceRoot>
+        <addSourceRoot>jansi-core/src/main/java</addSourceRoot>
+        <addSourceRoot>native/src/main/java</addSourceRoot>
+        <addSourceRoot>reader/src/main/java</addSourceRoot>
+        <addSourceRoot>style/src/main/java</addSourceRoot>
+        <addSourceRoot>terminal-jni/src/main/java</addSourceRoot>
+        <addSourceRoot>terminal/src/main/java</addSourceRoot>
+        <excludeSourceClass>org/jline/builtins/Commands</excludeSourceClass>
+        <excludeSourceClass>org/jline/builtins/Less</excludeSourceClass>
+        <excludeSourceClass>org/jline/builtins/Nano</excludeSourceClass>
+      </compiler>
+      <!--
+      <ant>
+        <run>
+          [property environment="env"/]
+          [property name="env.JAVA_HOME" value="/usr/lib/jvm/java"/]
+          [property name="env.CC" value="cc"/]
+          [property name="env.CFLAGS" value="-g -Wall -Wextra"/]
+          [property name="env.LDFLAGS" value=""/]
+          [exec executable="${env.CC}" failonerror="true"]
+            [arg line="-std=c99 -shared -fPIC"/]
+            [arg value="-I${env.JAVA_HOME}/include"/]
+            [arg value="-I${env.JAVA_HOME}/include/linux"/]
+            [arg line="${env.CFLAGS}"/]
+            [arg line="${env.LDFLAGS}"/]
+            [arg value="-o"/]
+            [arg value="${classes}/jline.so"/]
+            [arg value="${basedir}/native/src/main/native/jlinenative.c"/]
+          [/exec]
+        </run>
+      </ant>
+      -->
+    </build>
+  </module>
+</project>

--- a/project/maven-resolver2.properties
+++ b/project/maven-resolver2.properties
@@ -1,0 +1,3 @@
+url=https://github.com/apache/maven-resolver.git
+ref=maven-resolver-@.@.@
+version=2.0.5

--- a/project/maven-resolver2.xml
+++ b/project/maven-resolver2.xml
@@ -1,0 +1,24 @@
+<project>
+  <licensing>
+    <tag>Apache-2.0</tag>
+  </licensing>
+  <module>
+    <dependency>slf4j</dependency>
+    <dependency>guice</dependency>
+    <dependency>injection-api</dependency>
+    <dependency>sisu-inject</dependency>
+    <dependency>gson</dependency>
+    <build>
+      <compiler>
+        <addSourceRoot>maven-resolver-api/src/main/java</addSourceRoot>
+        <addSourceRoot>maven-resolver-spi/src/main/java</addSourceRoot>
+        <addSourceRoot>maven-resolver-impl/src/main/java</addSourceRoot>
+        <addSourceRoot>maven-resolver-util/src/main/java</addSourceRoot>
+        <addSourceRoot>maven-resolver-connector-basic/src/main/java</addSourceRoot>
+        <addSourceRoot>maven-resolver-transport-file/src/main/java</addSourceRoot>
+        <addSourceRoot>maven-resolver-named-locks/src/main/java</addSourceRoot>
+      </compiler>
+      <sisu/>
+    </build>
+  </module>
+</project>

--- a/project/plexus-interactivity.properties
+++ b/project/plexus-interactivity.properties
@@ -1,0 +1,3 @@
+url=https://github.com/codehaus-plexus/plexus-interactivity
+ref=plexus-interactivity-@.@
+version=1.3

--- a/project/plexus-interactivity.xml
+++ b/project/plexus-interactivity.xml
@@ -1,0 +1,37 @@
+<project>
+  <licensing>
+    <tag>MIT</tag>
+    <text>The MIT License
+
+Copyright (c) 2005, The Codehaus
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+    </text>
+  </licensing>
+  <module>
+    <dependency>jline3</dependency>
+    <dependency>injection-api</dependency>
+    <build>
+      <compiler>
+        <addSourceRoot>plexus-interactivity-api/src/main/java</addSourceRoot>
+      </compiler>
+      <sisu/>
+    </build>
+  </module>
+</project>

--- a/project/plexus-sec-dispatcher4.properties
+++ b/project/plexus-sec-dispatcher4.properties
@@ -1,0 +1,3 @@
+url=https://github.com/codehaus-plexus/plexus-sec-dispatcher.git
+ref=plexus-sec-dispatcher-@.@.@
+version=4.0.3

--- a/project/plexus-sec-dispatcher4.xml
+++ b/project/plexus-sec-dispatcher4.xml
@@ -1,0 +1,23 @@
+<project>
+  <licensing>
+    <tag>Apache-2.0</tag>
+  </licensing>
+  <module>
+    <dependency>injection-api</dependency>
+    <dependency>plexus-utils</dependency>
+    <dependency>plexus-cipher</dependency>
+    <dependency>slf4j</dependency>
+    <build>
+      <modello>
+        <model>src/main/mdo/settings-security.mdo</model>
+        <version>4.0.0</version>
+        <output>java|stax-reader|stax-writer</output>
+      </modello>
+      <compiler>
+        <release>17</release>
+        <addSourceRoot>src/main/java</addSourceRoot>
+      </compiler>
+      <sisu/>
+    </build>
+  </module>
+</project>

--- a/project/slf4j2.properties
+++ b/project/slf4j2.properties
@@ -1,0 +1,3 @@
+url=https://github.com/qos-ch/slf4j.git
+ref=v_@.@.@
+version=2.0.16

--- a/project/slf4j2.xml
+++ b/project/slf4j2.xml
@@ -1,0 +1,24 @@
+<project>
+  <licensing>
+    <tag>MIT AND Apache-2.0</tag>
+    <file>LICENSE.txt</file>
+  </licensing>
+  <module>
+    <build>
+      <compiler>
+        <addSourceRoot>slf4j-api/src/main/java</addSourceRoot>
+        <addSourceRoot>slf4j-simple/src/main/java</addSourceRoot>
+      </compiler>
+    </build>
+  </module>
+  <module>
+    <name>jcl-over-slf4j2</name>
+    <subDir>jcl-over-slf4j</subDir>
+    <dependency>slf4j</dependency>
+    <build>
+      <compiler>
+        <addSourceRoot>src/main/java</addSourceRoot>
+      </compiler>
+    </build>
+  </module>
+</project>

--- a/project/stax2-api.properties
+++ b/project/stax2-api.properties
@@ -1,0 +1,3 @@
+url=https://github.com/FasterXML/stax2-api
+ref=stax2-api-@.@.@
+version=4.2.2

--- a/project/stax2-api.xml
+++ b/project/stax2-api.xml
@@ -1,0 +1,15 @@
+<project>
+  <licensing>
+    <tag>BSD-2-Clause</tag>
+    <file>src/main/resources/META-INF/LICENSE</file>
+  </licensing>
+  <module>
+    <build>
+      <compiler>
+        <release>9</release>
+        <addSourceRoot>src/main/java</addSourceRoot>
+        <addSourceRoot>src/moditect</addSourceRoot>
+      </compiler>
+    </build>
+  </module>
+</project>

--- a/project/woodstox.properties
+++ b/project/woodstox.properties
@@ -1,0 +1,4 @@
+url=https://github.com/FasterXML/woodstox
+ref=woodstox-core-@.@.@
+version=7.1.0
+rpm_name=woodstox-core

--- a/project/woodstox.xml
+++ b/project/woodstox.xml
@@ -1,0 +1,18 @@
+<project>
+  <licensing>
+    <tag>Apache-2.0</tag>
+  </licensing>
+  <module>
+    <dependency>stax2-api</dependency>
+    <build>
+      <jurand>
+        <source>src/main/java</source>
+        <pattern>^aQute.bnd.annotation.spi.</pattern>
+      </jurand>
+      <compiler>
+        <excludeSourceMatching>/com/ctc/wstx/msv/.*</excludeSourceMatching>
+        <excludeSourceMatching>/com/ctc/wstx/osgi/.*</excludeSourceMatching>
+      </compiler>
+    </build>
+  </module>
+</project>


### PR DESCRIPTION
Add several projects that will be required for building Maven 4:

- gson
- jline3
- maven-resolver2
- plexus-interactivity
- plexus-sec-dispatcher4
- slf4j2
- stax2-api
- woodstox
