### PR TITLE
Improve usage of class loaders

### DIFF
--- a/mbi/ant/src/org/fedoraproject/mbi/tool/ant/AntTool.java
+++ b/mbi/ant/src/org/fedoraproject/mbi/tool/ant/AntTool.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import org.apache.tools.ant.ExitException;
 import org.apache.tools.ant.Main;
 import org.fedoraproject.mbi.tool.Instruction;
+import org.fedoraproject.mbi.tool.ProjectClassScope;
 import org.fedoraproject.mbi.tool.ThreadUnsafe;
 import org.fedoraproject.mbi.tool.Tool;
 
@@ -34,6 +35,7 @@ import org.fedoraproject.mbi.tool.Tool;
  * @author Mikolaj Izdebski
  */
 @ThreadUnsafe
+@ProjectClassScope
 public class AntTool
     extends Tool
 {
@@ -71,7 +73,8 @@ public class AntTool
         Path buildFile = getReactor().getTargetDir( getModule() ).resolve( "ant-run.xml" );
         Files.createDirectories( buildFile.getParent() );
 
-        try ( OutputStream os = Files.newOutputStream( buildFile ); PrintStream ps = new PrintStream( os, false, StandardCharsets.UTF_8 ) )
+        try ( OutputStream os = Files.newOutputStream( buildFile );
+                        PrintStream ps = new PrintStream( os, false, StandardCharsets.UTF_8 ) )
         {
             ps.println( "<project default=\"antrun\" basedir=\"" + baseDir + "\">" );
             ps.println( "<property name=\"classes\" location=\"" + classesDir + "\"/>" );
@@ -95,7 +98,8 @@ public class AntTool
                 {
                     throw new ExitException( exitCode );
                 }
-            }.startAnt( new String[] { "-f", buildFile.toString() }, null, null );
+            }.startAnt( new String[] { "-f", buildFile.toString() }, null,
+                        Thread.currentThread().getContextClassLoader() );
         }
         catch ( ExitException e )
         {

--- a/mbi/core/src/org/fedoraproject/mbi/dist/DistCommand.java
+++ b/mbi/core/src/org/fedoraproject/mbi/dist/DistCommand.java
@@ -15,7 +15,6 @@
  */
 package org.fedoraproject.mbi.dist;
 
-import java.net.URLClassLoader;
 import java.nio.file.Path;
 
 import org.fedoraproject.mbi.Command;
@@ -54,11 +53,9 @@ public class DistCommand
                                                installRoot, mavenHomePath, metadataPath, artifactsPath, launchersPath,
                                                licensesPath );
 
-        try ( URLClassLoader cl = ToolUtils.newClassLoader( reactor, distModule ) )
-        {
-            Thread.currentThread().setContextClassLoader( cl );
-            Class<?> distMainClass = cl.loadClass( "org.fedoraproject.mbi.tool.dist.DistMain" );
-            distMainClass.getMethod( "main", DistRequest.class ).invoke( null, request );
-        }
+        ClassLoader cl = ToolUtils.newClassLoader( null, reactor, distModule );
+        Thread.currentThread().setContextClassLoader( cl );
+        Class<?> distMainClass = cl.loadClass( "org.fedoraproject.mbi.tool.dist.DistMain" );
+        distMainClass.getMethod( "main", DistRequest.class ).invoke( null, request );
     }
 }

--- a/mbi/core/src/org/fedoraproject/mbi/tool/ProjectClassScope.java
+++ b/mbi/core/src/org/fedoraproject/mbi/tool/ProjectClassScope.java
@@ -1,0 +1,28 @@
+/*-
+ * Copyright (c) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fedoraproject.mbi.tool;
+
+import static java.lang.annotation.ElementType.TYPE;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target( TYPE )
+@Retention( RetentionPolicy.RUNTIME )
+public @interface ProjectClassScope
+{
+}

--- a/mbi/modello/src/org/fedoraproject/mbi/tool/modello/ModelloTool.java
+++ b/mbi/modello/src/org/fedoraproject/mbi/tool/modello/ModelloTool.java
@@ -33,6 +33,7 @@ import org.codehaus.plexus.DefaultPlexusContainer;
 import org.codehaus.plexus.PlexusConstants;
 import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.PlexusContainerException;
+import org.codehaus.plexus.classworlds.ClassWorld;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 import org.fedoraproject.mbi.tool.Instruction;
 import org.fedoraproject.mbi.tool.Tool;
@@ -112,6 +113,7 @@ public class ModelloTool
         try
         {
             ContainerConfiguration conf = new DefaultContainerConfiguration();
+            conf.setClassWorld( new ClassWorld( "plexus.core", ModelloTool.class.getClassLoader() ) );
             conf.setClassPathScanning( PlexusConstants.SCANNING_INDEX );
             conf.setAutoWiring( true );
             PlexusContainer container = new DefaultPlexusContainer( conf );

--- a/mbi/plexus/src/org/fedoraproject/mbi/tool/plexus/PlexusTool.java
+++ b/mbi/plexus/src/org/fedoraproject/mbi/tool/plexus/PlexusTool.java
@@ -34,6 +34,7 @@ import javax.xml.transform.stream.StreamResult;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.fedoraproject.mbi.tool.Instruction;
+import org.fedoraproject.mbi.tool.ProjectClassScope;
 import org.fedoraproject.mbi.tool.Tool;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -43,6 +44,7 @@ import org.w3c.dom.NodeList;
 /**
  * @author Mikolaj Izdebski
  */
+@ProjectClassScope
 public class PlexusTool
     extends Tool
 {
@@ -136,7 +138,7 @@ public class PlexusTool
         {
             String className =
                 getClassesDir().relativize( classFile ).toString().replaceAll( ".class$", "" ).replace( '/', '.' );
-            Class<?> cls = getClass().getClassLoader().loadClass( className );
+            Class<?> cls = Thread.currentThread().getContextClassLoader().loadClass( className );
             if ( cls.isAnnotationPresent( Component.class ) )
             {
                 Annotation plexus = cls.getAnnotationsByType( Component.class )[0];

--- a/mbi/sisu/src/org/fedoraproject/mbi/tool/sisu/SisuTool.java
+++ b/mbi/sisu/src/org/fedoraproject/mbi/tool/sisu/SisuTool.java
@@ -24,11 +24,13 @@ import java.util.stream.Collectors;
 
 import javax.inject.Named;
 
+import org.fedoraproject.mbi.tool.ProjectClassScope;
 import org.fedoraproject.mbi.tool.Tool;
 
 /**
  * @author Mikolaj Izdebski
  */
+@ProjectClassScope
 public class SisuTool
     extends Tool
 {
@@ -43,7 +45,7 @@ public class SisuTool
         {
             String className =
                 getClassesDir().relativize( classFile ).toString().replaceAll( ".class$", "" ).replace( '/', '.' );
-            Class<?> cls = getClass().getClassLoader().loadClass( className );
+            Class<?> cls = Thread.currentThread().getContextClassLoader().loadClass( className );
             if ( cls.isAnnotationPresent( Named.class ) )
             {
                 namedComponents.add( cls.getName() );


### PR DESCRIPTION
Class loaders are not discarded after use, but kept cached, so that subsequent use of the same class loader can reuse already loaded (and possibly JIT-compiled) classes.

Tool class loaders are separated from combined tool-project class loaders, so that tool class loaders can be reused when the same tool is ran on different projects.

Combined tool-project class loader is not even created unless particular tool is annotated with `@ProjectClassScope`, which means that the tool needs a class loader that includes project classes.