### PR TITLE
Explicitly enable annotation processing

### DIFF
--- a/mbi/core/src/org/fedoraproject/mbi/tool/compiler/CompilerTool.java
+++ b/mbi/core/src/org/fedoraproject/mbi/tool/compiler/CompilerTool.java
@@ -160,6 +160,7 @@ public class CompilerTool
             options.add( "--release" );
             options.add( release + "" );
         }
+        options.add( "-proc:full" );
         options.add( "-cp" );
         options.add( getClassPath().stream().map( Path::toString ).collect( Collectors.joining( ":" ) ) );
         StringWriter compilerOutput = new StringWriter();


### PR DESCRIPTION
Up to JDK 22, `-proc:full` (annotation processing + compilation) was the default.  From JDK 23 onward, the compiler uses `-proc:none` by default.  We must now explicitly pass `-proc:full` to enable annotation processing.