### PR TITLE
Un-exclude ant logic attributes

### DIFF
--- a/project/ant.xml
+++ b/project/ant.xml
@@ -12,10 +12,6 @@
         <addSourceRoot>src/main</addSourceRoot>
         <addResource>src/main</addResource>
         <addResource>src/resources</addResource>
-        <excludeSourceClass>org/apache/tools/ant/attribute/BaseIfAttribute</excludeSourceClass>
-        <excludeSourceClass>org/apache/tools/ant/attribute/IfBlankAttribute</excludeSourceClass>
-        <excludeSourceClass>org/apache/tools/ant/attribute/IfSetAttribute</excludeSourceClass>
-        <excludeSourceClass>org/apache/tools/ant/attribute/IfTrueAttribute</excludeSourceClass>
         <excludeSourceClass>org/apache/tools/ant/dispatch/DispatchTask</excludeSourceClass>
         <excludeSourceClass>org/apache/tools/ant/filters/ConcatFilter</excludeSourceClass>
         <excludeSourceClass>org/apache/tools/ant/filters/Native2AsciiFilter</excludeSourceClass>


### PR DESCRIPTION
This is needed to simplify `xz-java` update in Fedora: https://src.fedoraproject.org/rpms/xz-java/pull-request/7